### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -451,7 +451,7 @@ Enti.get = function(model, key){
     return model[key];
 };
 Enti.set = function(model, key, value){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 
@@ -483,7 +483,7 @@ Enti.set = function(model, key, value){
     emit(events);
 };
 Enti.push = function(model, key, value){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 
@@ -515,7 +515,7 @@ Enti.push = function(model, key, value){
     emit(events);
 };
 Enti.insert = function(model, key, value, index){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 
@@ -549,7 +549,7 @@ Enti.insert = function(model, key, value, index){
     emit(events);
 };
 Enti.remove = function(model, key, subKey){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 
@@ -575,7 +575,7 @@ Enti.remove = function(model, key, subKey){
     emit(events);
 };
 Enti.move = function(model, key, index){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 
@@ -601,7 +601,7 @@ Enti.move = function(model, key, index){
     emit([[model, index, item]]);
 };
 Enti.update = function(model, key, value, options){
-    if(!model || typeof model !== 'object'){
+    if(!model || typeof model !== 'object' || model === Object.prototype){
         return;
     }
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`enti` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-enti

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('enti')

console.log('Before:', {}.polluted)
set({}, '__proto__.polluted', true)
console.log('After:', {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i enti # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/114258275-2e661500-99e3-11eb-9fd2-7f607e286fc5.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
